### PR TITLE
Backwards compatibility

### DIFF
--- a/im_anim.cpp
+++ b/im_anim.cpp
@@ -11,13 +11,13 @@
 #include <windows.h>
 #endif
 
-#define IMGUI_VERSION_BAKEDFONT 19200
+#define IMGUI_VERSION_BAKEDFONT 19200 //The version number where ImFontBaked and global ImGuiStoragePair were introduced
 #if defined(IMGUI_VERSION_NUM) && IMGUI_VERSION_NUM >= IMGUI_VERSION_BAKEDFONT
-	// ImGuiStoragePair is in global namespace in newer ImGui
+	// ImGuiStoragePair is in the global namespace since ImGui version 1.92.0 (19200)
 #define IMGUI_STORAGE_PAIR ImGuiStoragePair
 typedef ImFontBaked FontType;
 #else
-	// ImGuiStoragePair is nested in ImGuiStorage in older ImGui
+	// ImGuiStoragePair is nested in ImGuiStorage in Pre-1.92.0 versions
 #define IMGUI_STORAGE_PAIR ImGuiStorage::ImGuiStoragePair
 typedef ImFont FontType;
 #endif


### PR DESCRIPTION
Hey, I noticed that this library does not support any version of ImGui earlier than 1.92.0. 

I'm using a heavily modified version of 1.90.1, which makes updating non-trivial, but I wanted to test this project out. So I had to make it work for 1.90.1

This PR enables people using an ImGui version prior to the inclusion of the "ImFontBaked" and the global ImGuiStoragePair type to run this project.

Based on the version, we detect whether to use ImFont or ImFontBaked. We also get the type via the helper function GetBakedFont(), which will return either type depending on the ImGui version.

I've also wrapped PI and TWO_PI  in ifndef blocks, as it can clash with other libraries that also define PI/TWO_PI. Additionally, I've moved them to the top as TWO_PI was defined in two places. It might be worth considering renaming them to avoid clashes with external macros, and perhaps making them local to the functions. But the way it is now will work, but it comes with the small risk that an external macro named "PI" could be something else and not the actual values of PI. 

[This commit ](https://github.com/ocornut/imgui/commit/093d01269a05d5f6fab9eee85d3e187b22364fe7#diff-cbc47f9fc55eb2c19b4be92d1c1e137bb8b72d072588ab3cb4bcba88576d14cb)introduced ImFontBaked.  Any commit prior to that would not work with this project. But it should now.

It works in 1.90.1. But this branch needs testing with the latest ImGui.
