### PR TITLE
Fix for ImGui 1.92.8 AddRect/AddPolyline/PathStroke arg swap

### DIFF
--- a/im_anim.cpp
+++ b/im_anim.cpp
@@ -7470,7 +7470,11 @@ void iam_show_debug_timeline(ImGuiID instance_id) {
 			else if (mouse.x >= x1 && mouse.x <= x2 && mouse.y >= seg_y1 && mouse.y <= seg_y2) {
 				// Segment hover tooltip (for easing between keyframes)
 				// Highlight hovered segment
+#if IMGUI_VERSION_NUM < 19276
 				dl->AddRect(ImVec2(x1, seg_y1), ImVec2(x2, seg_y2), playhead_color, 2.0f, 0, 2.0f);
+#else
+				dl->AddRect(ImVec2(x1, seg_y1), ImVec2(x2, seg_y2), playhead_color, 2.0f, 2.0f);
+#endif
 
 				ImGui::BeginTooltip();
 				ImGui::Text("Segment: %.2fs - %.2fs", key_time, next_time);

--- a/im_anim_demo.cpp
+++ b/im_anim_demo.cpp
@@ -65,7 +65,11 @@ static void DrawRotatedRect(ImDrawList* dl, ImVec2 ctr, ImVec2 size, float angle
 	}
 	dl->AddConvexPolyFilled(pts, 4, fill);
 	if ((border & IM_COL32_A_MASK) > 0)
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddPolyline(pts, 4, border, ImDrawFlags_Closed, 1.5f);
+#else
+		dl->AddPolyline(pts, 4, border, 1.5f, ImDrawFlags_Closed);
+#endif
 }
 
 // Helper: Draw a rotated ellipse
@@ -3261,10 +3265,17 @@ static void ShowClipSystemDemo()
 					IM_COL32(250, 250, 245, a), 6.0f);
 
 				// Card border
+#if IMGUI_VERSION_NUM < 19276
 				cards_draw_list->AddRect(
 					ImVec2(x + offset_x, y + offset_y),
 					ImVec2(x + offset_x + scaled_w, y + offset_y + scaled_h),
 					IM_COL32(180, 180, 175, a), 6.0f, 0, 1.5f);
+#else
+				cards_draw_list->AddRect(
+					ImVec2(x + offset_x, y + offset_y),
+					ImVec2(x + offset_x + scaled_w, y + offset_y + scaled_h),
+					IM_COL32(180, 180, 175, a), 6.0f, 1.5f);
+#endif
 
 				// Suit text
 				ImU32 text_col = (card_colors[i] & 0x00FFFFFF) | ((a & 0xFF) << 24);
@@ -4746,13 +4757,23 @@ static void ShowDrawListDemo()
 		// Glow effect
 		for (int g = 3; g >= 1; --g) {
 			int glow_alpha = (int)(pulse * 30.0f / g);
+#if IMGUI_VERSION_NUM < 19276
 			draw_list->AddPolyline(heart_points, HEART_SEGMENTS, IM_COL32(255, 50, 80, glow_alpha),
 				ImDrawFlags_Closed, 2.0f + g * 3.0f);
+#else
+			draw_list->AddPolyline(heart_points, HEART_SEGMENTS, IM_COL32(255, 50, 80, glow_alpha),
+				2.0f + g * 3.0f, ImDrawFlags_Closed);
+#endif
 		}
 
 		draw_list->AddConvexPolyFilled(heart_points, HEART_SEGMENTS, IM_COL32(180, 30, 60, heart_alpha));
+#if IMGUI_VERSION_NUM < 19276
 		draw_list->AddPolyline(heart_points, HEART_SEGMENTS, IM_COL32(255, 80, 100, 255),
 			ImDrawFlags_Closed, 2.0f);
+#else
+		draw_list->AddPolyline(heart_points, HEART_SEGMENTS, IM_COL32(255, 80, 100, 255),
+			2.0f, ImDrawFlags_Closed);
+#endif
 
 		// ECG Line (right side)
 		float ecg_left = canvas_pos.x + 160.0f;
@@ -4794,7 +4815,11 @@ static void ShowDrawListDemo()
 			ecg_pts[i] = ImVec2(ecg_left + x_norm * ecg_width, ecg_center_y - y);
 		}
 
+#if IMGUI_VERSION_NUM < 19276
 		draw_list->AddPolyline(ecg_pts, ECG_POINTS, IM_COL32(80, 255, 80, 255), 0, 2.0f);
+#else
+		draw_list->AddPolyline(ecg_pts, ECG_POINTS, IM_COL32(80, 255, 80, 255), 2.0f);
+#endif
 
 		// Scanning dot
 		float dot_x = ecg_left + beat_phase * ecg_width;
@@ -7371,7 +7396,11 @@ static void ShowStressTestDemo()
 						int g = (int)(ImClamp(val.y, 0.0f, 1.0f) * 255);
 						int b = (int)(ImClamp(val.z, 0.0f, 1.0f) * 255);
 						dl->AddRectFilled(ImVec2(cell_left, cell_top), ImVec2(cell_right, cell_bottom), IM_COL32(r, g, b, 255));
+#if IMGUI_VERSION_NUM < 19276
 						dl->AddRect(ImVec2(cell_left, cell_top), ImVec2(cell_right, cell_bottom), IM_COL32(255, 255, 255, 100), 0.0f, 0, 1.0f);
+#else
+						dl->AddRect(ImVec2(cell_left, cell_top), ImVec2(cell_right, cell_bottom), IM_COL32(255, 255, 255, 100), 0.0f, 1.0f);
+#endif
 						break;
 					}
 					case 4: // Mixed - different visualization per cell type

--- a/im_anim_doc.cpp
+++ b/im_anim_doc.cpp
@@ -3492,10 +3492,17 @@ static void DocSection_PerAxisEasing()
 			ImVec2(canvas_pos.x + swatch_margin, canvas_pos.y + swatch_margin),
 			ImVec2(canvas_pos.x + swatch_margin + swatch_size, canvas_pos.y + swatch_margin + swatch_size),
 			swatch_col, 8.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(
 			ImVec2(canvas_pos.x + swatch_margin, canvas_pos.y + swatch_margin),
 			ImVec2(canvas_pos.x + swatch_margin + swatch_size, canvas_pos.y + swatch_margin + swatch_size),
 			IM_COL32(255, 255, 255, 100), 8.0f, 0, 2.0f);
+#else
+		dl->AddRect(
+			ImVec2(canvas_pos.x + swatch_margin, canvas_pos.y + swatch_margin),
+			ImVec2(canvas_pos.x + swatch_margin + swatch_size, canvas_pos.y + swatch_margin + swatch_size),
+			IM_COL32(255, 255, 255, 100), 8.0f, 2.0f);
+#endif
 
 		// Draw individual channel bars (scaled up)
 		float bar_x = canvas_pos.x + swatch_margin + swatch_size + 30.0f;
@@ -4175,7 +4182,11 @@ static void DocSection_ClipCallbacks()
 		// Begin box
 		ImU32 col_begin = IM_COL32(100 + (int)(155 * cb_state.begin_flash), 60, 60, 255);
 		dl->AddRectFilled(box_begin, ImVec2(box_begin.x + box_w, box_begin.y + box_h), col_begin, 6.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(box_begin, ImVec2(box_begin.x + box_w, box_begin.y + box_h), IM_COL32(200, 100, 100, 255), 6.0f, 0, 2.0f);
+#else
+		dl->AddRect(box_begin, ImVec2(box_begin.x + box_w, box_begin.y + box_h), IM_COL32(200, 100, 100, 255), 6.0f, 2.0f);
+#endif
 		dl->AddText(font, font_size * 1.1f, ImVec2(box_begin.x + 20, box_begin.y + 14), IM_COL32_WHITE, "on_begin");
 		char buf[32];
 		snprintf(buf, sizeof(buf), "Count: %d", cb_state.begin_count);
@@ -4184,7 +4195,11 @@ static void DocSection_ClipCallbacks()
 		// Update box
 		ImU32 col_update = IM_COL32(60, 100 + (int)(155 * cb_state.update_flash), 60, 255);
 		dl->AddRectFilled(box_update, ImVec2(box_update.x + box_w, box_update.y + box_h), col_update, 6.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(box_update, ImVec2(box_update.x + box_w, box_update.y + box_h), IM_COL32(100, 200, 100, 255), 6.0f, 0, 2.0f);
+#else
+		dl->AddRect(box_update, ImVec2(box_update.x + box_w, box_update.y + box_h), IM_COL32(100, 200, 100, 255), 6.0f, 2.0f);
+#endif
 		dl->AddText(font, font_size * 1.1f, ImVec2(box_update.x + 20, box_update.y + 14), IM_COL32_WHITE, "on_update");
 		snprintf(buf, sizeof(buf), "Count: %d", cb_state.update_count);
 		dl->AddText(font, font_size, ImVec2(box_update.x + 20, box_update.y + 42), IM_COL32(220, 220, 220, 255), buf);
@@ -4192,7 +4207,11 @@ static void DocSection_ClipCallbacks()
 		// Complete box
 		ImU32 col_complete = IM_COL32(60, 60, 100 + (int)(155 * cb_state.complete_flash), 255);
 		dl->AddRectFilled(box_complete, ImVec2(box_complete.x + box_w, box_complete.y + box_h), col_complete, 6.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(box_complete, ImVec2(box_complete.x + box_w, box_complete.y + box_h), IM_COL32(100, 100, 200, 255), 6.0f, 0, 2.0f);
+#else
+		dl->AddRect(box_complete, ImVec2(box_complete.x + box_w, box_complete.y + box_h), IM_COL32(100, 100, 200, 255), 6.0f, 2.0f);
+#endif
 		dl->AddText(font, font_size * 1.1f, ImVec2(box_complete.x + 20, box_complete.y + 14), IM_COL32_WHITE, "on_complete");
 		snprintf(buf, sizeof(buf), "Count: %d", cb_state.complete_count);
 		dl->AddText(font, font_size, ImVec2(box_complete.x + 20, box_complete.y + 42), IM_COL32(220, 220, 220, 255), buf);
@@ -5786,9 +5805,15 @@ static void DocSection_TransformMatrix()
 
 		// Draw original unit square (before transform)
 		float half = 30.0f;
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(ImVec2(center.x - half, center.y - half),
 			ImVec2(center.x + half, center.y + half),
 			IM_COL32(100, 100, 100, 128), 0.0f, 0, 1.0f);
+#else
+		dl->AddRect(ImVec2(center.x - half, center.y - half),
+			ImVec2(center.x + half, center.y + half),
+			IM_COL32(100, 100, 100, 128), 0.0f, 1.0f);
+#endif
 
 		// Draw transformed square
 		ImVec2 corners[4] = {

--- a/im_anim_usecase.cpp
+++ b/im_anim_usecase.cpp
@@ -120,8 +120,13 @@ static void ShowUsecase_AnimatedButton()
 		ImU32 fill_color = IM_COL32(91, 194, 231, (int)(fill_alpha * 255));
 		dl->AddRectFilled(btn_pos, ImVec2(btn_pos.x + btn_size.x, btn_pos.y + btn_size.y),
 			fill_color, 8.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(btn_pos, ImVec2(btn_pos.x + btn_size.x, btn_pos.y + btn_size.y),
 			border_color, 8.0f, 0, border);
+#else
+		dl->AddRect(btn_pos, ImVec2(btn_pos.x + btn_size.x, btn_pos.y + btn_size.y),
+			border_color, 8.0f, border);
+#endif
 
 		const char* label = "Ghost";
 		ImVec2 text_size = ImGui::CalcTextSize(label);
@@ -556,8 +561,13 @@ static void ShowUsecase_CardHover()
 		// Draw card background
 		dl->AddRectFilled(drawn_pos, ImVec2(drawn_pos.x + card_size.x, drawn_pos.y + card_size.y),
 			IM_COL32(45, 48, 58, 255), 8.0f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(drawn_pos, ImVec2(drawn_pos.x + card_size.x, drawn_pos.y + card_size.y),
 			ImGui::ColorConvertFloat4ToU32(border_color), 8.0f, 0, 1.5f);
+#else
+		dl->AddRect(drawn_pos, ImVec2(drawn_pos.x + card_size.x, drawn_pos.y + card_size.y),
+			ImGui::ColorConvertFloat4ToU32(border_color), 8.0f, 1.5f);
+#endif
 
 		// Draw title
 		ImVec2 title_pos(drawn_pos.x + 16.0f, drawn_pos.y + 20.0f);
@@ -2320,10 +2330,17 @@ static void ShowUsecase_FlipCard()
 
 			// Pattern on back
 			float pattern_offset = half_width * 0.3f;
+#if IMGUI_VERSION_NUM < 19276
 			dl->AddRect(
 				ImVec2(card_min.x + pattern_offset, card_min.y + 20),
 				ImVec2(card_max.x - pattern_offset, card_max.y - 20),
 				IM_COL32(255, 255, 255, 100), 4.0f, 0, 2.0f);
+#else
+			dl->AddRect(
+				ImVec2(card_min.x + pattern_offset, card_min.y + 20),
+				ImVec2(card_max.x - pattern_offset, card_max.y - 20),
+				IM_COL32(255, 255, 255, 100), 4.0f, 2.0f);
+#endif
 
 			// Back text
 			const char* back_text = "SECRET!";
@@ -2668,8 +2685,13 @@ static void ShowUsecase_SearchExpand()
 	// Draw search bar background
 	dl->AddRectFilled(bar_pos, ImVec2(bar_pos.x + width, bar_pos.y + bar_height),
 		IM_COL32(45, 48, 60, 255), bar_height * 0.5f);
+#if IMGUI_VERSION_NUM < 19276
 	dl->AddRect(bar_pos, ImVec2(bar_pos.x + width, bar_pos.y + bar_height),
 		expanded ? IM_COL32(91, 194, 231, 255) : IM_COL32(70, 75, 90, 255), bar_height * 0.5f, 0, 1.5f);
+#else
+	dl->AddRect(bar_pos, ImVec2(bar_pos.x + width, bar_pos.y + bar_height),
+		expanded ? IM_COL32(91, 194, 231, 255) : IM_COL32(70, 75, 90, 255), bar_height * 0.5f, 1.5f);
+#endif
 
 	// Search icon
 	ImVec2 icon_center(bar_pos.x + 20, bar_pos.y + bar_height * 0.5f);
@@ -2875,7 +2897,11 @@ static void ShowUsecase_CircularProgress()
 
 		// Background ring
 		dl->PathArcTo(center, ring_radius, 0.0f, IM_PI * 2.0f, 32);
+#if IMGUI_VERSION_NUM < 19276
 		dl->PathStroke(IM_COL32(45, 48, 58, 255), 0, ring_thickness);
+#else
+		dl->PathStroke(IM_COL32(45, 48, 58, 255), ring_thickness);
+#endif
 
 		// Progress arc (starting from top, going clockwise)
 		float start_angle = -IM_PI * 0.5f;
@@ -2883,7 +2909,11 @@ static void ShowUsecase_CircularProgress()
 		if (progress_values[i] > 0.01f)
 		{
 			dl->PathArcTo(center, ring_radius, start_angle, end_angle, 32);
+#if IMGUI_VERSION_NUM < 19276
 			dl->PathStroke(colors[i], 0, ring_thickness);
+#else
+			dl->PathStroke(colors[i], ring_thickness);
+#endif
 		}
 
 		// Percentage text
@@ -6172,18 +6202,31 @@ static void ShowUsecase_GlowingBorder()
 	{
 		float layer_size = glow_size * (1.0f + i * 0.3f);
 		float layer_alpha = glow_alpha * (1.0f - i * 0.25f);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(
 			ImVec2(pos.x - layer_size, pos.y - layer_size),
 			ImVec2(pos.x + box_size.x + layer_size, pos.y + box_size.y + layer_size),
 			IM_COL32(100, 180, 255, (int)(layer_alpha * 255)),
 			12 * scale + i * 2 * scale, 0, 2.0f + i);
+#else
+		dl->AddRect(
+			ImVec2(pos.x - layer_size, pos.y - layer_size),
+			ImVec2(pos.x + box_size.x + layer_size, pos.y + box_size.y + layer_size),
+			IM_COL32(100, 180, 255, (int)(layer_alpha * 255)),
+			12 * scale + i * 2 * scale, 2.0f + i);
+#endif
 	}
 
 	// Main box
 	dl->AddRectFilled(pos, ImVec2(pos.x + box_size.x, pos.y + box_size.y),
 		IM_COL32(40, 45, 55, 255), 8 * scale);
+#if IMGUI_VERSION_NUM < 19276
 	dl->AddRect(pos, ImVec2(pos.x + box_size.x, pos.y + box_size.y),
 		IM_COL32(100, 180, 255, 255), 8 * scale, 0, 2.0f);
+#else
+	dl->AddRect(pos, ImVec2(pos.x + box_size.x, pos.y + box_size.y),
+		IM_COL32(100, 180, 255, 255), 8 * scale, 2.0f);
+#endif
 
 	// Content
 	const char* text = "Featured Item";
@@ -6296,10 +6339,17 @@ static void ShowUsecase_AnimatedGraphNode()
 			ImVec2(node_pos.x - offset.x, node_pos.y - offset.y),
 			ImVec2(node_pos.x - offset.x + scaled_size.x, node_pos.y - offset.y + scaled_size.y),
 			IM_COL32(50, 55, 65, 255), 6 * scale);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(
 			ImVec2(node_pos.x - offset.x, node_pos.y - offset.y),
 			ImVec2(node_pos.x - offset.x + scaled_size.x, node_pos.y - offset.y + scaled_size.y),
 			nodes[i].color, 6 * scale, 0, 2.0f);
+#else
+		dl->AddRect(
+			ImVec2(node_pos.x - offset.x, node_pos.y - offset.y),
+			ImVec2(node_pos.x - offset.x + scaled_size.x, node_pos.y - offset.y + scaled_size.y),
+			nodes[i].color, 6 * scale, 2.0f);
+#endif
 
 		// Label
 		ImVec2 text_size = ImGui::CalcTextSize(nodes[i].label);
@@ -6743,7 +6793,11 @@ static void ShowUsecase_DownloadProgressButton()
 		float start_angle = -3.14159f * 0.5f;
 		float end_angle = start_angle + progress * 3.14159f * 2.0f;
 		dl->PathArcTo(center, 15 * scale, start_angle, end_angle, 32);
+#if IMGUI_VERSION_NUM < 19276
 		dl->PathStroke(IM_COL32(255, 255, 255, 255), 0, 3 * scale);
+#else
+		dl->PathStroke(IM_COL32(255, 255, 255, 255), 3 * scale);
+#endif
 
 		char pct[8];
 		snprintf(pct, sizeof(pct), "%.0f%%", progress * 100);
@@ -6820,7 +6874,11 @@ static void ShowUsecase_SubmitButtonStates()
 		// Spinner
 		float r = 10 * scale;
 		dl->PathArcTo(center, r, spinner_angle, spinner_angle + 4.0f, 16);
+#if IMGUI_VERSION_NUM < 19276
 		dl->PathStroke(IM_COL32(255, 255, 255, 255), 0, 2 * scale);
+#else
+		dl->PathStroke(IM_COL32(255, 255, 255, 255), 2 * scale);
+#endif
 	}
 	else
 	{
@@ -7819,7 +7877,11 @@ static void ShowUsecase_PullToRefresh()
 		{
 			// Spinning
 			dl->PathArcTo(ind_center, 10 * scale, refresh_angle, refresh_angle + 4.0f, 16);
+#if IMGUI_VERSION_NUM < 19276
 			dl->PathStroke(IM_COL32(100, 150, 255, 255), 0, 2 * scale);
+#else
+			dl->PathStroke(IM_COL32(100, 150, 255, 255), 2 * scale);
+#endif
 		}
 		else
 		{
@@ -7888,7 +7950,11 @@ static void ShowUsecase_DataFetchStates()
 	{
 		// Spinner
 		dl->PathArcTo(center, 15 * scale, spinner_angle, spinner_angle + 4.0f, 16);
+#if IMGUI_VERSION_NUM < 19276
 		dl->PathStroke(IM_COL32(100, 150, 255, 255), 0, 3 * scale);
+#else
+		dl->PathStroke(IM_COL32(100, 150, 255, 255), 3 * scale);
+#endif
 		dl->AddText(ImVec2(center.x - 30 * scale, center.y + 25 * scale), IM_COL32(150, 150, 160, 255), "Loading...");
 	}
 	else
@@ -8515,8 +8581,13 @@ static void ShowUsecase_SearchInput()
 
 		dl->AddRectFilled(picker_pos, ImVec2(picker_pos.x + picker_width, picker_pos.y + picker_height),
 			IM_COL32(40, 45, 55, (int)(240 * picker_anim)), 20 * scale * picker_anim);
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(picker_pos, ImVec2(picker_pos.x + picker_width, picker_pos.y + picker_height),
 			IM_COL32(80, 85, 95, (int)(200 * picker_anim)), 20 * scale * picker_anim, 0, 1.5f * scale);
+#else
+		dl->AddRect(picker_pos, ImVec2(picker_pos.x + picker_width, picker_pos.y + picker_height),
+			IM_COL32(80, 85, 95, (int)(200 * picker_anim)), 20 * scale * picker_anim, 1.5f * scale);
+#endif
 
 		// Draw reaction options
 		for (int i = 0; i < 5; i++)
@@ -8752,8 +8823,13 @@ static void ShowUsecase_ProductCard()
 	{
 		float pulse = iam_oscillate(ImGui::GetID("pulse"), 1.0f, 1.0f, 0, 0.0f, dt);
 		pulse = pulse * 0.5f + 0.5f;  // Convert -1..1 to 0..1
+#if IMGUI_VERSION_NUM < 19276
 		dl->AddRect(art_pos, ImVec2(art_pos.x + art_size, art_pos.y + art_size),
 			IM_COL32(150, 120, 200, (int)(50 + 50 * pulse)), 24 * scale, 0, 6 * scale);
+#else
+		dl->AddRect(art_pos, ImVec2(art_pos.x + art_size, art_pos.y + art_size),
+			IM_COL32(150, 120, 200, (int)(50 + 50 * pulse)), 24 * scale, 6 * scale);
+#endif
 	}
 
 	// Song info


### PR DESCRIPTION
See https://github.com/ocornut/imgui/releases/tag/v1.92.8



<img width="1188" height="302" alt="image" src="https://github.com/user-attachments/assets/b63cae1c-506c-4402-a184-c353a6cd47c2" />




Gate the 27 affected call sites on IMGUI_VERSION_NUM < 19276 were swapped to (thickness, flags) in ocornut/imgui v1.92.8.